### PR TITLE
Fix indentation for ports in docker-compose.yaml

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -40,7 +40,7 @@ services:
     container_name: consul
     command: agent -server -bootstrap-expect=1 -ui -bind=0.0.0.0 -client=0.0.0.0
     ports:
-         "8500:8500"
+      - "8500:8500"
     volumes:
       - ./kv-data.json:/kv-data.json
       - ./load-kv.sh:/load-kv.sh


### PR DESCRIPTION
Adjusted the indentation of the ports section to ensure valid YAML syntax and proper functioning of the docker-compose file. This change prevents potential parsing errors when deploying the services.